### PR TITLE
cpufreq: dt-platdev: add mediatek,mt7988a to blocklist

### DIFF
--- a/drivers/cpufreq/cpufreq-dt-platdev.c
+++ b/drivers/cpufreq/cpufreq-dt-platdev.c
@@ -132,6 +132,7 @@ static const struct of_device_id blocklist[] __initconst = {
 	{ .compatible = "mediatek,mt2712", },
 	{ .compatible = "mediatek,mt7622", },
 	{ .compatible = "mediatek,mt7623", },
+	{ .compatible = "mediatek,mt7988a", },
 	{ .compatible = "mediatek,mt8167", },
 	{ .compatible = "mediatek,mt817x", },
 	{ .compatible = "mediatek,mt8173", },

--- a/drivers/cpufreq/mediatek-cpufreq.c
+++ b/drivers/cpufreq/mediatek-cpufreq.c
@@ -736,7 +736,11 @@ static const struct mtk_cpufreq_platform_data mt8516_platform_data = {
 	.ccifreq_supported = false,
 };
 
-/* List of machines supported by this driver */
+/*
+ * List of machines supported by this driver
+ *
+ * Make sure to add any new entries to the blocklist in cpufreq-dt-platdev.c
+ */
 static const struct of_device_id mtk_cpufreq_machines[] __initconst __maybe_unused = {
 	{ .compatible = "mediatek,mt2701", .data = &mt2701_platform_data },
 	{ .compatible = "mediatek,mt2712", .data = &mt2701_platform_data },


### PR DESCRIPTION
This platform uses the mtk-cpufreq driver, but the lists got out of sync. This resulted in a race condition that could result in cpufreq-dt being used instead of the platform driver.

Add a comment to the platform driver too, to try and prevent this from happening again.

Fixes: b69ec356db1a7c4703b1a9edc82ee1dfdd296b97 ("cpufreq: mediatek: Add support for MT7988A")