### PR TITLE
arm64: dts: mediatek: mt7988a-bpi-r4: always keep rt5190_buck3 on

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -247,6 +247,7 @@
 				regulator-min-microvolt = <600000>;
 				regulator-max-microvolt = <1400000>;
 				regulator-boot-on;
+				regulator-always-on;
 			};
 			buck4 {
 				regulator-name = "rt5190a-buck4";


### PR DESCRIPTION
The system seems to reliably hang when mtk-ccifreq turns off the processor regulator.