### PR TITLE
net: pcs: pcs-mtk-lynxi: fix with CONFIG_FWNODE_PCS=m

### DIFF
--- a/drivers/net/pcs/pcs-mtk-lynxi.c
+++ b/drivers/net/pcs/pcs-mtk-lynxi.c
@@ -413,7 +413,7 @@ void mtk_pcs_lynxi_destroy(struct phylink_pcs *pcs)
 }
 EXPORT_SYMBOL(mtk_pcs_lynxi_destroy);
 
-#ifdef CONFIG_FWNODE_PCS
+#if IS_ENABLED(CONFIG_FWNODE_PCS)
 static int mtk_pcs_lynxi_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;


### PR DESCRIPTION
Fixes: b6e969abaff10ffd65dce5b79c76c7ba8f38fea4 ("net: pcs: pcs-mtk-lynxi: add platform driver for MT7988")