### PR TITLE
cpufreq: mediatek: disable building as a module

### DIFF
--- a/drivers/cpufreq/Kconfig.arm
+++ b/drivers/cpufreq/Kconfig.arm
@@ -123,7 +123,7 @@ config ARM_KIRKWOOD_CPUFREQ
 	  SoCs.
 
 config ARM_MEDIATEK_CPUFREQ
-	tristate "CPU Frequency scaling support for MediaTek SoCs"
+	bool "CPU Frequency scaling support for MediaTek SoCs"
 	depends on ARCH_MEDIATEK || COMPILE_TEST
 	depends on REGULATOR
 	select PM_OPP

--- a/drivers/cpufreq/mediatek-cpufreq.c
+++ b/drivers/cpufreq/mediatek-cpufreq.c
@@ -757,7 +757,6 @@ static const struct of_device_id mtk_cpufreq_machines[] __initconst __maybe_unus
 	{ .compatible = "mediatek,mt8516", .data = &mt8516_platform_data },
 	{ }
 };
-MODULE_DEVICE_TABLE(of, mtk_cpufreq_machines);
 
 static int __init mtk_cpufreq_driver_init(void)
 {


### PR DESCRIPTION
This cannot be automatically probed as a loadable module, as it matches on the compatible field for the board, which is not exposed to userspace as a device that could have its modalias processed. Other cpufreq drivers that act like this do not support being built as modules. Support for building as a module was added due to a dependency on THERMAL, but this was resolved in afa1f2ab43d48d0e1fa1bda524a0cf53e4cd6c87 ("thermal: cpu_cooling: Require thermal core to be compiled in").

A handful of cpufreq drivers are the only device drivers that try to match against board compatible fields like this. A better solution may be to make this a proper platform device that can appear in the device tree, or perhaps even replace it with cpufreq-dt entirely using coupled regulators, but this is the simplest fix.

Fixes: af6eca06501118af3e2ad46eee8edab20624b74e ("cpufreq: mediatek: Add missing MODULE_DEVICE_TABLE")
Fixes: 3c2002aec3ee3a9fc86ff8f8618f1253c94ec919 ("cpufreq: mediatek: allow building as a module")