### PR TITLE
arm64: dts: mediatek: mt7988a-bpi-r4: add serial0 alias

### DIFF
--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -13,6 +13,7 @@
 		ethernet0 = &gmac0;
 		ethernet1 = &gmac1;
 		ethernet2 = &gmac2;
+		serial0 = &serial0;
 	};
 
 	chosen {


### PR DESCRIPTION
This is required for the stdout-path to work.

Fixes: 2f2f9a4a2bc647e397e74f276f02eb0b82de39e8 ("arm64: dts: mediatek: mt7988a-bpi-r4: Add default UART stdout")