### PR TITLE
clk: mediatek: clk-mt7988-apmixed: add missing MODULE_DEVICE_TABLE

### DIFF
--- a/drivers/clk/mediatek/clk-mt7988-apmixed.c
+++ b/drivers/clk/mediatek/clk-mt7988-apmixed.c
@@ -75,6 +75,7 @@ static const struct of_device_id of_match_clk_mt7988_apmixed[] = {
 	{ .compatible = "mediatek,mt7988-apmixedsys" },
 	{ /* sentinel */ }
 };
+MODULE_DEVICE_TABLE(of, of_match_clk_mt7988_apmixed);
 
 static int clk_mt7988_apmixed_probe(struct platform_device *pdev)
 {


### PR DESCRIPTION
This is required when building as a loadable module.

Fixes: 4b4719437d85f0173d344f2c76fa1a5b7f7d184b ("clk: mediatek: add drivers for MT7988 SoC")