### PR TITLE
net: phylink: add optional dependency on FWNODE_PCS

### DIFF
--- a/drivers/net/phy/Kconfig
+++ b/drivers/net/phy/Kconfig
@@ -7,6 +7,7 @@ config PHYLINK
 	tristate
 	select PHYLIB
 	select SWPHY
+	depends on FWNODE_PCS || !FWNODE_PCS
 	help
 	  PHYlink models the link between the PHY and MAC, allowing fixed
 	  configuration links, PHYs, and Serdes links with MAC level


### PR DESCRIPTION
This prevents a build error when CONFIG_PHYLINK=y and CONFIG_FWNODE_PCS=m.

Fixes: b832f1b0446cd45c03c112c8b612043e748a2560 ("net: phylink: support late PCS provider attach")