### PR TITLE
uio: uio_pdrv_genirq: remove incorrect MODULE_DEVICE_TABLE

### DIFF
--- a/drivers/uio/uio_pdrv_genirq.c
+++ b/drivers/uio/uio_pdrv_genirq.c
@@ -276,7 +276,6 @@ static struct of_device_id uio_of_genirq_match[] = {
 	{ /* This is filled with module_parm */ },
 	{ /* Sentinel */ },
 };
-MODULE_DEVICE_TABLE(of, uio_of_genirq_match);
 module_param_string(of_id, uio_of_genirq_match[0].compatible, 128, 0);
 MODULE_PARM_DESC(of_id, "Openfirmware id of the device to be handled by uio");
 #endif


### PR DESCRIPTION
This was harmless albeit useless when it was added, but the placeholder table entry added later causes it to get the wildcard modaliases of:N*T* and of:N*T*C*, which match every possible node.

This means that it is unnecessarily loaded on any machine that probes for a module for a device tree node with no assigned driver, and silently produces bizarre results for modprobe(8) and modinfo(8) commands that should properly fail.

Fixes: 05c3e0bb5629b897b0459e4bfb1b93d729033b99 ("UIO: allow binding uio_pdrv_genirq.c to devices using command line option")